### PR TITLE
BO-360-BUG: Create Category

### DIFF
--- a/src/global/components/Menu/Menu.tsx
+++ b/src/global/components/Menu/Menu.tsx
@@ -18,10 +18,10 @@ export const Menu = ({ initialState }: MenuProps) => {
       {initialState.map((category) => (
         <Link
           className={clsx("menu__item", {
-            "menu__item--active": pathname === `/categories/${category.slug}`,
+            "menu__item--active": pathname === `/categories/${category.id}`,
           })}
           key={category.slug}
-          href={`/categories/${category.slug}`}
+          href={`/categories/${category.id}`}
         >
           {category.name}
         </Link>

--- a/src/modules/categories/components/FormEditCategory/FormEditCategory.tsx
+++ b/src/modules/categories/components/FormEditCategory/FormEditCategory.tsx
@@ -74,7 +74,7 @@ export default function FormEditCategory({
         onSuccess: (updatedCategory) => {
           onSuccess?.();
           toast.success(CATEGORY_SUCCESSES.EDIT_CATEGORY_SUCCESS);
-          router.push(`/categories/${updatedCategory.slug}`);
+          router.push(`/categories/${updatedCategory.id}`);
         },
         onError: () => {
           toast.error(CATEGORY_ERRORS.UPDATE_CATEGORY_ERROR);

--- a/src/modules/categories/components/FormNewCategory/FormNewCategory.tsx
+++ b/src/modules/categories/components/FormNewCategory/FormNewCategory.tsx
@@ -40,7 +40,7 @@ export default function FormNewCategory() {
       onSuccess: (createdCategory) => {
         toast.success(CATEGORY_SUCCESSES.CREATE_CATEGORY_SUCCESS);
         // Navigate immediately without clearing form state to prevent freezing
-        router.push(`/categories/${createdCategory.slug}`);
+        router.push(`/categories/${createdCategory.id}`);
       },
       onError: () => {
         // Error handling is done by the global error handler


### PR DESCRIPTION
Problem: When trying to create a category with a slug named "new" it would open the new category form again instead of redirecting it to the category page.
Solution: Change the routes to use the category Id instead, so i changed the routes on FormNewCategory, FormEditCategory and Menu to `/categories/{category.id}`, making it redirect to the category page when created/edited/accessed.

[BO-360](https://toraline.atlassian.net/jira/software/c/projects/BO/boards/44?selectedIssue=BO-360)

[BO-360]: https://toraline.atlassian.net/browse/BO-360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ