### PR TITLE
BO-359-BUG: Task notification

### DIFF
--- a/src/modules/tasks/components/FormEditTask/FormEditTask.tsx
+++ b/src/modules/tasks/components/FormEditTask/FormEditTask.tsx
@@ -88,8 +88,7 @@ export default function FormEditTask({
             }
           }
         },
-      },
-      {
+
         onError: (error) => {
           console.error(TASK_ERRORS.UPDATE_TASK_ERROR, error);
         },


### PR DESCRIPTION
Problem: whenever you check or uncheck the task checkbox it would fire two sonner notifications.
Solution: deleted the notification firing conditions from the onSubmit onSuccess and added them to the onChecked onSuccess firing specific notifications for the checkbox, and checkbox only.

[BO-359](https://toraline.atlassian.net/browse/BO-359)

[BO-359]: https://toraline.atlassian.net/browse/BO-359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ