### PR TITLE
[BO-176]: add direct url to prisma config

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,8 +3,9 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
 }
 
 enum UserStatus {


### PR DESCRIPTION
DIRECT_URL will be used run migrations, and DATABASE_URL to all the other queries. We need this so one is uses a connection with pooler (DATABASE_URL) and the other without pooler (DIRECT_URL)