### PR TITLE
BO-411-BUG:UI: Role bug on delete button

### DIFF
--- a/src/modules/roles/components/EditStateRole/EditStateRole.tsx
+++ b/src/modules/roles/components/EditStateRole/EditStateRole.tsx
@@ -77,8 +77,7 @@ export default function EditStateRole({ roleId }: { roleId: string }) {
           onClick={onDelete}
           disabled={deleteRoleMutation.isPending}
         >
-          Delete
-          {deleteRoleMutation.isPending && GLOBAL_UI.BUTTONS.DELETING}
+          {deleteRoleMutation.isPending ? GLOBAL_UI.BUTTONS.DELETING : GLOBAL_UI.BUTTONS.DELETE}
         </Button>
       )}
     </div>


### PR DESCRIPTION
[BO-411](https://toraline.atlassian.net/browse/BO-411)
After our first Bug Bash it was found a bug on the delete button at the route `/admin/roles/:id` . I fixed by adding a conditional at the button children so it would show "Delete" or "Deleting..." according to its state.

[BO-411]: https://toraline.atlassian.net/browse/BO-411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ