### PR TITLE
BO-377-BUG: UI Admin: Create user

### DIFF
--- a/src/modules/users/components/FormNewUser/FormNewUser.tsx
+++ b/src/modules/users/components/FormNewUser/FormNewUser.tsx
@@ -76,7 +76,9 @@ export const FormNewUser = () => {
           type="url"
           id="imageUrlInput"
           placeholder={USER_CONSTANTS.PLACEHOLDERS.PROFILE_PICTURE}
-          {...register("avatarUrl")}
+          {...register("avatarUrl", {
+            setValueAs: (value) => (value === "" ? undefined : value),
+          })}
           error={errors.avatarUrl?.message}
         />
 

--- a/src/modules/users/schema.ts
+++ b/src/modules/users/schema.ts
@@ -7,7 +7,7 @@ export const userStatusSchema = z.enum(["ACTIVE", "INVITED", "SUSPENDED"]);
 
 export const userIdSchema = z.cuid();
 
-export const emailSchema = z.string().trim().email();
+export const emailSchema = z.email().trim();
 
 export const roleIdSchema = z.cuid();
 export const roleKeySchema = z.string().trim().min(1).max(120);
@@ -25,7 +25,7 @@ export const nameSchema = z
   .min(1, VALIDATION_MESSAGES.NAME_TOO_SHORT)
   .max(120, VALIDATION_MESSAGES.NAME_TOO_LONG);
 
-export const avatarUrlSchema = z.string().trim().optional();
+export const avatarUrlSchema = z.url().trim().optional().nullable();
 
 export const tenantIdSchema = z.string().trim().min(1).max(120);
 
@@ -37,7 +37,7 @@ const clerkUserIdOptionalSchema = clerkUserIdSchema.optional();
 export const createUserSchema = z.object({
   email: emailSchema,
   name: nameSchema,
-  avatarUrl: avatarUrlSchema.optional(),
+  avatarUrl: avatarUrlSchema,
   // BO-230 remove the optional from the status when adding Clerk
   status: userStatusSchema.optional(),
   tenantId: tenantIdOptionalSchema,


### PR DESCRIPTION
[BO-377](https://toraline.atlassian.net/browse/BO-403)
The createUser form wasn't recognizing the `avatarUrl` field as a valid format saying it was a invalid url. I fixed using `setValueAs` from the register to convert the empty string in undefined to pass the zod validating system.

[BO-377]: https://toraline.atlassian.net/browse/BO-377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ